### PR TITLE
SerialOptions dictionary is now lowerCamelCase

### DIFF
--- a/script.js
+++ b/script.js
@@ -74,7 +74,7 @@ async function connect() {
   // - Request a port and open a connection.
   port = await navigator.serial.requestPort();
   // - Wait for the port to open.toggleUIConnected
-  await port.open({ baudrate: baudRate.value });
+  await port.open({ baudRate: baudRate.value });
 
   const encoder = new TextEncoderStream();
   outputDone = encoder.readable.pipeTo(port.writable);


### PR DESCRIPTION
So SerialOptions.baudrate is now SerialOptions.baudRate: https://wicg.github.io/serial/#dom-serialoptions-baudrate

Discussed in:
- https://github.com/WICG/serial/issues/93

Changed in:
- https://github.com/WICG/serial/pull/98

Without this change https://adafruit.github.io/Adafruit_WebSerial_Plotter/ currently throws this error on connection:
```
Uncaught (in promise) TypeError: Failed to execute 'open' on 'SerialPort': Failed to read the 'baudRate' property from 'SerialOptions': Required member is undefined.
    at connect (script.js:77:14)
    at async HTMLButtonElement.clickConnect (script.js:242:3)
```
<img width="808" alt="image" src="https://github.com/adafruit/Adafruit_WebSerial_Plotter/assets/4189262/3b3278ad-f7ed-4f6c-b17e-6e67318ec505">
